### PR TITLE
Extend student API

### DIFF
--- a/src/server/api/routers/student.ts
+++ b/src/server/api/routers/student.ts
@@ -6,6 +6,40 @@ import {
 } from "~/server/api/trpc";
 
 export const studentRouter = createTRPCRouter({
+  // Gets the basic details for a student based on their userId
+  getStudentDetails: publicProcedure
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const user = await ctx.prisma.user.findUnique({
+        where: {
+          id: input.userId,
+        },
+      });
+
+      if (!user) {
+        throw new Error(`User with id ${input.userId} not found`);
+      }
+
+      // Fetch the student with this userId
+      const student = await ctx.prisma.student.findUnique({
+        where: {
+          userId: user.id,
+        },
+      });
+
+      if (!student) {
+        throw new Error(`Student with id ${input.userId} not found (this should never be thrown)`);
+      }
+
+      return {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        studentId: student.studentId
+      };
+    }),
+
+
   // Gets all examSessions for a student (past and current)
   // Once the sessionID's are known, we can post further queries to get any recordings related to those sessions.
   getStudentSessions: publicProcedure
@@ -75,4 +109,63 @@ export const studentRouter = createTRPCRouter({
         notifications: notifications.flat(), // Flatten the array of arrays
       };
     }),
+
+  createNotification: publicProcedure
+  .input(z.object({ sessionId: z.number() }))
+  .query(async ({ input, ctx }) => {
+    const session = await ctx.prisma.examSession.findUnique({
+      where: {
+        sessionId: input.sessionId,
+      },
+    });
+
+    if (!session) {
+      throw new Error(`Session with id ${input.sessionId} not found`);
+    }
+
+    const student = await studentRouter.createCaller(ctx).getStudentDetails({ userId: String(session.studentId)})
+
+    // Create new notification relating to session
+    const notification = await ctx.prisma.notification.create({
+      data: {
+        content: `[Suspicious activity flagged] SID: ${session.studentId} Name: ${student.name}`,
+        sessionId: session.sessionId
+      },
+    });
+  }),
+
+  // Flag the session if suspicious activity has been found
+  // Create a notification relating to the session, store in DB
+  flagStudentSession: publicProcedure
+    .input(z.object({ sessionId: z.number() }))
+    .query(async ({ input, ctx }) => {
+      const session = await ctx.prisma.examSession.findUnique({
+        where: {
+          sessionId: input.sessionId,
+        },
+      });
+
+      if (!session) {
+        throw new Error(`Session with id ${input.sessionId} not found`);
+      }
+
+      // Update the session to set suspiciousActivity to true
+      const updatedSession = await ctx.prisma.examSession.update({
+        where: {
+          sessionId: input.sessionId,
+        },
+        data: {
+          suspiciousActivity: true,
+        },
+      });
+
+      // Create new notification
+      await studentRouter.createCaller(ctx).createNotification({ sessionId: session.sessionId})
+
+      // Ideally, we want the notifications to act like real-time events, so we will need to implement a design pattern with the teacher/admin API to check for any newly created
+      // notifications associated to any sessions they are overwatching.
+    }),
+  
+  
+
 });

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -37,7 +37,7 @@ interface CreateContextOptions {
  *
  * @see https://create.t3.gg/en/usage/trpc#-serverapitrpcts
  */
-const createInnerTRPCContext = (opts: CreateContextOptions) => {
+export const createInnerTRPCContext = (opts: CreateContextOptions) => {
   return {
     session: opts.session,
     prisma,


### PR DESCRIPTION
This PR extends the student API router, allowing the following functions:

`getStudentDetails`
- Takes a userID, returns a students name, email, studentID

`flagStudentSession`
- Takes a sessionID, updates the DB to flag the session and then creates a new notification associated with the session

`createNotification`
- Takes a sessionID (as all notifications must be assocaited to a session), and creates a new DB object with a hardcoded message `[Suspicious activity flagged] SID: ${session.studentId} Name: ${student.name}`

There has not been any testing for these functions, just due to time constraint and the setup required for something like Jest/Vitest which would require mocking DB. I think the easiest way to test with our constraints would just be to hook them up to the frontend, try them out and see where they break, and adjust from there. 

(Hooking upto frontend will also expose any other missing functions we might want for the student API)