### PR TITLE
Improve logic surrounding session ending and unique student sessions

### DIFF
--- a/src/pages/admin/session.tsx
+++ b/src/pages/admin/session.tsx
@@ -242,13 +242,18 @@ export default function Session() {
                     <p>No Image</p>
                   )
                 )}
-                {examSession.liveFeedImage && (
-                  <img
-                    src={examSession.liveFeedImage}
-                    className="h-50 object-scale-down"
-                  />
+                {examSession.liveFeedImage ? (
+                  examSession.liveFeedImage.trim() !== "" ? (
+                    <img
+                      src={examSession.liveFeedImage}
+                      className="h-50 object-scale-down"
+                    />
+                  ) : (
+                    <p>No webcam connected</p>
+                  )
+                ) : (
+                  <p>No webcam connected</p>
                 )}
-
                 <p>Student Name: {examSession.name}</p>
                 <p>Student ID: {examSession.sID}</p>
                 {examSession.suspiciousActivity ? (

--- a/src/pages/student/session.tsx
+++ b/src/pages/student/session.tsx
@@ -25,6 +25,11 @@ export default function Session() {
   useEffect(() => {
     // Log initial examSessions
     console.log(studentDetails.data);
+
+    // Check if the session is still valid (hasn't ended)
+    if (studentDetails.data?.endTime != null) {
+      router.push("/account")
+    }
   }, [studentDetails.data]);
 
   return (

--- a/src/pages/student/session.tsx
+++ b/src/pages/student/session.tsx
@@ -28,7 +28,7 @@ export default function Session() {
 
     // Check if the session is still valid (hasn't ended)
     if (studentDetails.data?.endTime != null) {
-      router.push("/account")
+      router.push("/account");
     }
   }, [studentDetails.data]);
 

--- a/src/server/api/routers/examSession.ts
+++ b/src/server/api/routers/examSession.ts
@@ -69,21 +69,24 @@ export const examSessionRouter = createTRPCRouter({
       const existingExamSessions = await ctx.prisma.examSession.findMany({
         where: {
           uniqueCode: input.uniqueCode,
-          studentId: student.id
+          studentId: student.id,
         },
       });
-      
+
       if (existingExamSessions.length > 0) {
-        console.log("Re-entering existing exam session", existingExamSessions[0])
-      
+        console.log(
+          "Re-entering existing exam session",
+          existingExamSessions[0]
+        );
+
         // Delete any other instances (incase any exist)
         for (let i = 1; i < existingExamSessions.length; i++) {
           const examSession = existingExamSessions[i];
           if (examSession) {
             await ctx.prisma.examSession.delete({
               where: {
-                sessionId: examSession.sessionId
-              }
+                sessionId: examSession.sessionId,
+              },
             });
           }
         }

--- a/src/server/api/routers/session.ts
+++ b/src/server/api/routers/session.ts
@@ -55,7 +55,7 @@ export const sessionRouter = createTRPCRouter({
       return { uniqueCode: createdSession.uniqueCode };
     }),
 
-  endSession: publicProcedure
+    endSession: publicProcedure
     .input(z.object({ uniqueCode: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const session = await ctx.prisma.createdSession.update({
@@ -66,10 +66,21 @@ export const sessionRouter = createTRPCRouter({
           valid: false,
         },
       });
-
-      console.log("Session invalidated");
+  
+      // End all associated examSessions
+      await ctx.prisma.examSession.updateMany({
+        where: {
+          uniqueCode: Number(input.uniqueCode),
+        },
+        data: {
+          endTime: new Date(), // setting endTime to the current date and time
+        },
+      });
+  
+      console.log("Session invalidated and associated examSessions ended");
       return session;
     }),
+  
 
   getStudentSession: publicProcedure
     .input(z.object({ uniqueCode: z.string(), studentId: z.string() }))

--- a/src/server/api/routers/session.ts
+++ b/src/server/api/routers/session.ts
@@ -55,7 +55,7 @@ export const sessionRouter = createTRPCRouter({
       return { uniqueCode: createdSession.uniqueCode };
     }),
 
-    endSession: publicProcedure
+  endSession: publicProcedure
     .input(z.object({ uniqueCode: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const session = await ctx.prisma.createdSession.update({
@@ -66,7 +66,7 @@ export const sessionRouter = createTRPCRouter({
           valid: false,
         },
       });
-  
+
       // End all associated examSessions
       await ctx.prisma.examSession.updateMany({
         where: {
@@ -76,11 +76,10 @@ export const sessionRouter = createTRPCRouter({
           endTime: new Date(), // setting endTime to the current date and time
         },
       });
-  
+
       console.log("Session invalidated and associated examSessions ended");
       return session;
     }),
-  
 
   getStudentSession: publicProcedure
     .input(z.object({ uniqueCode: z.string(), studentId: z.string() }))


### PR DESCRIPTION
Students were able to create multiple examSessions for one createdSession by leaving the session and then re-joining. This was due to the Join button calling `createExamSession` without checking if a valid examSession already existed.

- Fixed by checking if an existing valid examSession already exists. If it does, then return that instead of creating a new one.

After the teacher ends the exam session, the student was not kicked out of the examSession page.

- Fixed by adding a `useEffect` to student session page that continiously checks if the examSession `endTime` is null. If the `endTime` is not null, this means the createdSession has become invalided (i.e. ended), and we kick them out of the examSession page.