### PR TITLE
Improve 'stream' between student and teacher client

### DIFF
--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -189,22 +189,19 @@ const Camera = (): JSX.Element => {
 
   React.useEffect(() => {
     const intervalId = setInterval(() => {
-      console.log("Live feed image consolelog");
       if (!cameraRef.current || !studentDetails.data) return;
-      const imageSrc = cameraRef.current.getScreenshot();
-      console.log(imageSrc);
+      const imageSrc = cameraRef.current.getScreenshot() ?? "";
       addLiveFeedImage
         .mutateAsync({
           sessionId: studentDetails.data.sessionId,
           image: imageSrc ?? "",
         })
-        .then((res) => console.log(res));
-    }, 7500);
+    }, 1000);
 
     return () => {
       clearInterval(intervalId);
     };
-  }, [handleAnalyse]);
+  }, [handleAnalyse, studentDetails.data]);
 
   //const AWS = require("aws-sdk");
   const config = {

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -191,11 +191,10 @@ const Camera = (): JSX.Element => {
     const intervalId = setInterval(() => {
       if (!cameraRef.current || !studentDetails.data) return;
       const imageSrc = cameraRef.current.getScreenshot() ?? "";
-      addLiveFeedImage
-        .mutateAsync({
-          sessionId: studentDetails.data.sessionId,
-          image: imageSrc ?? "",
-        })
+      addLiveFeedImage.mutateAsync({
+        sessionId: studentDetails.data.sessionId,
+        image: imageSrc ?? "",
+      });
     }, 1000);
 
     return () => {

--- a/src/pages/admin/session.tsx
+++ b/src/pages/admin/session.tsx
@@ -41,6 +41,9 @@ export default function Session() {
   const getExamSessionsByCode = api.examSessions.getExamSessionsByCode.useQuery(
     {
       uniqueCode: sessionCode,
+    },
+    {
+      refetchInterval: 1000
     }
   );
 
@@ -51,14 +54,13 @@ export default function Session() {
 
   const router = useRouter();
 
-  console.log(examSessions);
 
   useEffect(() => {
     if (getExamSessionsByCode.data) {
-      setExamSessions(getExamSessionsByCode.data.examSessions);
+        if (JSON.stringify(examSessions) !== JSON.stringify(getExamSessionsByCode.data.examSessions))
+        console.log(getExamSessionsByCode.data.examSessions);
+        setExamSessions(getExamSessionsByCode.data.examSessions);
     }
-    // Log initial examSessions
-    console.log(getExamSessionsByCode.data?.examSessions);
   }, [getExamSessionsByCode.data]);
 
   useEffect(() => {

--- a/src/pages/admin/session.tsx
+++ b/src/pages/admin/session.tsx
@@ -43,7 +43,7 @@ export default function Session() {
       uniqueCode: sessionCode,
     },
     {
-      refetchInterval: 1000
+      refetchInterval: 1000,
     }
   );
 
@@ -54,12 +54,14 @@ export default function Session() {
 
   const router = useRouter();
 
-
   useEffect(() => {
     if (getExamSessionsByCode.data) {
-        if (JSON.stringify(examSessions) !== JSON.stringify(getExamSessionsByCode.data.examSessions))
+      if (
+        JSON.stringify(examSessions) !==
+        JSON.stringify(getExamSessionsByCode.data.examSessions)
+      )
         console.log(getExamSessionsByCode.data.examSessions);
-        setExamSessions(getExamSessionsByCode.data.examSessions);
+      setExamSessions(getExamSessionsByCode.data.examSessions);
     }
   }, [getExamSessionsByCode.data]);
 

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -16,3 +16,12 @@ export default createNextApiHandler({
         }
       : undefined,
 });
+
+export const config = {
+  api: {
+      bodyParser: {
+          sizeLimit: '100mb',
+      },
+      responseLimit: '100mb',
+  }
+}

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -19,9 +19,9 @@ export default createNextApiHandler({
 
 export const config = {
   api: {
-      bodyParser: {
-          sizeLimit: '100mb',
-      },
-      responseLimit: '100mb',
-  }
-}
+    bodyParser: {
+      sizeLimit: "100mb",
+    },
+    responseLimit: "100mb",
+  },
+};


### PR DESCRIPTION
- Teacher dashboard now automatically refetches examSessions to show any new ones, instead of having to reload the page to invoke the useEffect()
- Fixed a bug where `studentDetails.data` would return undefined in `Camera.tsx` when adding the live image feed @LachlanBWWright (fixed by adding `studentDetails.data` to the useEffect dependency array)
- Increased server request limit from 1MB to 100MB to allow all screenshots to uplod without error, increased frequency of screenshots from 7500 to 1000 ms (to get a more 'streamy' feel)

TODO:
- Continue looking into WebRTC methods to have an actual stream connection instead of saving screenshots in DB, however failing that, the current 'stream' I think can suffice. I'll leave this in draft until ~Friday when I'll determine if the stream is feasible or not.